### PR TITLE
fix: adopt forward-compatible approach to `builder:watch`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,4 @@
+import { relative, resolve } from 'node:path'
 import { IconGenerator } from '@coremyslo/icon-generator';
 import { FontGenerator } from '@coremyslo/font-generator';
 import { AssetGenerator } from "@coremyslo/asset-generator";
@@ -136,6 +137,7 @@ export default defineNuxtModule<ModuleOptions>({
     let timeout: ReturnType<typeof setTimeout>;
 
     nuxt.hook("builder:watch", async (event, path) => {
+      path = relative(nuxt.options.srcDir, resolve(nuxt.options.srcDir, path))
       if (!path.includes(options.sourceDirPath || "") || !path.match(/\.(svg)$/)) {
         return;
       }


### PR DESCRIPTION
We are planning to move to [emitting absolute paths in `builder:watch` in Nuxt v4](https://github.com/nuxt/nuxt/issues/25339). You can see a little more about the history in the PR linked in that issue.

This PR is an attempt to use a forward/backward compatible approach, namely resolving the path to ensure it's absolute, then making it relative so your existing code will continue to work.

This should be safe to merge as is, but do let me know if you have any concerns about this approach.

